### PR TITLE
Fix wrong content-length for apis with that header

### DIFF
--- a/plugins/kong/plugins/xml-2-json-transformer/handler.lua
+++ b/plugins/kong/plugins/xml-2-json-transformer/handler.lua
@@ -16,6 +16,7 @@ function XML2JsonHandler:header_filter(conf)
   if kong.response.get_header("Content-Type") == "application/xml" then 
     check = true
     kong.response.clear_header("Content-Type")
+    kong.response.clear_header("Content-Length") -- kong.response.set_raw_body(body) can't clear the Content-Length header and would only work for responses without a content header if we did not clear it here.
     kong.response.set_header("Content-Type", "application/json", string)
   end
 end


### PR DESCRIPTION
Currently the plugin will not work if the upstream api sets the content-length header because kong.response.set_raw_body(body) cant change the content-length header as documented by [Kong](https://docs.konghq.com/gateway/3.4.x/plugin-development/pdk/kong.response/#kongresponseset_raw_bodybody).
By clearing the content-length header in the header_filter this bug can be fixed.